### PR TITLE
feat: add support for assets URL

### DIFF
--- a/src/defaultConfig/webpack.config.js
+++ b/src/defaultConfig/webpack.config.js
@@ -16,6 +16,7 @@ const plugins = [
     NODE_ENV: 'development',
     DEBUG: false,
     PUBLIC_URL: '',
+    PUBLIC_ASSETS_URL: '',
   }),
 ];
 


### PR DESCRIPTION
This is useful if you want to upload static assets per widget in a component library like Storybook.