### PR TITLE
feat: support for external dependencies

### DIFF
--- a/src/command.test.ts
+++ b/src/command.test.ts
@@ -41,7 +41,7 @@ describe('command', () => {
         ],
         logger,
       );
-    } catch (error: any) {
+    } catch (error: unknown) {
       expect(logger).toHaveBeenCalledTimes(1);
     }
   });

--- a/src/command.ts
+++ b/src/command.ts
@@ -58,11 +58,9 @@ export default async (
     logger(`Config file: ${opts.configFile}`);
     logger(`New version: ${opts.newVersion}`);
   } catch (error: unknown) {
-    logger(
-      `[FATAL ERROR] ${
-        JSON.parse(JSON.stringify(error)) || ''
-      }\n\n${program.helpInformation()}`,
-    );
+    if (error instanceof Error) {
+      logger(`[FATAL ERROR] ${error || ''}\n\n${program.helpInformation()}`);
+    }
     throw error;
   }
   // For now we don't allow bringing in your own webpack configuration file. In
@@ -83,7 +81,9 @@ export default async (
       try {
         return loadWidgetDefinitionFile(filename);
       } catch (error: unknown) {
-        logger(`[WARNING] ${JSON.parse(JSON.stringify(error)).message || ''}`);
+        if (error instanceof Error) {
+          logger(`[WARNING] ${error.message || ''}`);
+        }
       }
     })
     .filter((i) => i);
@@ -113,9 +113,9 @@ export default async (
       });
     });
   } catch (error: unknown) {
-    compiler
-      .getInfrastructureLogger('CLI')
-      .error(JSON.parse(JSON.stringify(error)).message);
+    if (error instanceof Error) {
+      compiler.getInfrastructureLogger('CLI').error(error.message);
+    }
     process.exit(1);
     process.chdir(cwd);
   }

--- a/src/command.ts
+++ b/src/command.ts
@@ -9,6 +9,7 @@ import buildWebpackConfiguration from './webpack/buildWebpackConfiguration';
 import webpack, { Stats } from 'webpack';
 import { WidgetDefinition } from 'WidgetDefinition';
 import writeNewRegistry from './registry/writeNewRegistry';
+import { SideEffects } from 'common';
 
 function initProgram(program: Command, argv: string[]): void {
   program
@@ -40,7 +41,7 @@ function initProgram(program: Command, argv: string[]): void {
 export default async (
   program: Command,
   argv: string[],
-  logger: (input: string) => void,
+  logger: SideEffects,
 ): Promise<void> => {
   initProgram(program, argv);
   let opts;
@@ -56,9 +57,11 @@ export default async (
     logger(`Source dir: ${opts.sourceDir}`);
     logger(`Config file: ${opts.configFile}`);
     logger(`New version: ${opts.newVersion}`);
-  } catch (error: any) {
+  } catch (error: unknown) {
     logger(
-      `[FATAL ERROR] ${error.message || ''}\n\n${program.helpInformation()}`,
+      `[FATAL ERROR] ${
+        JSON.parse(JSON.stringify(error)) || ''
+      }\n\n${program.helpInformation()}`,
     );
     throw error;
   }
@@ -79,8 +82,8 @@ export default async (
     .map((filename) => {
       try {
         return loadWidgetDefinitionFile(filename);
-      } catch (error: any) {
-        logger(`[WARNING] ${error.message || ''}`);
+      } catch (error: unknown) {
+        logger(`[WARNING] ${JSON.parse(JSON.stringify(error)).message || ''}`);
       }
     })
     .filter((i) => i);
@@ -109,8 +112,10 @@ export default async (
         err || !stats ? reject(err) : resolve(stats);
       });
     });
-  } catch (error: any) {
-    compiler.getInfrastructureLogger('CLI').error(error.message);
+  } catch (error: unknown) {
+    compiler
+      .getInfrastructureLogger('CLI')
+      .error(JSON.parse(JSON.stringify(error)).message);
     process.exit(1);
     process.chdir(cwd);
   }

--- a/src/defaultConfig/webpack.config.js
+++ b/src/defaultConfig/webpack.config.js
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-const path = require('path');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const { EnvironmentPlugin } = require('webpack');

--- a/src/registry/buildNewRegistry.ts
+++ b/src/registry/buildNewRegistry.ts
@@ -5,6 +5,7 @@ import validateRegistry from './validateRegistry';
 import { WidgetRegistry, WidgetRegistryItem } from 'WidgetRegistry';
 import { WidgetDefinition } from 'WidgetDefinition';
 import currentTime from '../util/currentTime';
+import { RegistryConfig } from 'RegistryConfig';
 
 export default function buildNewRegistry(
   omitMissing: boolean,
@@ -13,6 +14,7 @@ export default function buildNewRegistry(
   templateUrl: string,
   pathToCompiledWidgets: string,
   version: string,
+  externalPeerDependencies: RegistryConfig['externalPeerDependencies'],
 ): WidgetRegistry {
   const compiledFiles = exploreCompiledWidgets(
     existingRegistry,
@@ -50,6 +52,7 @@ export default function buildNewRegistry(
           .replace(/{majorVersion}/, `v${semverMajor(version)}`),
         shortcode,
         version,
+        externalPeerDependencies,
       };
       return newItem;
     },

--- a/src/registry/buildTemplatedDirectoryUrl.ts
+++ b/src/registry/buildTemplatedDirectoryUrl.ts
@@ -1,10 +1,10 @@
 import { dirname as pathDirname } from 'path';
 import { RegistryConfig } from 'RegistryConfig';
 
-export default async function buildTemplatedDirectoryUrl(
+export default function buildTemplatedDirectoryUrl(
   registryConfig: RegistryConfig,
   existingRegistryFile: string,
-) {
+): string {
   const directoryUrl = registryConfig.directoryUrl.replace(/\/$/, '') || '';
   try {
     const remoteUrl = new URL(directoryUrl);

--- a/src/registry/buildTemplatedDirectoryUrl.ts
+++ b/src/registry/buildTemplatedDirectoryUrl.ts
@@ -1,11 +1,10 @@
 import { dirname as pathDirname } from 'path';
-import loadWidgetRegistryConfig from '../webpack/widgetDefinition/loadWidgetRegistryConfig';
+import { RegistryConfig } from 'RegistryConfig';
 
 export default async function buildTemplatedDirectoryUrl(
-  registryConfigFile: string,
+  registryConfig: RegistryConfig,
   existingRegistryFile: string,
 ) {
-  const registryConfig = await loadWidgetRegistryConfig(registryConfigFile);
   const directoryUrl = registryConfig.directoryUrl.replace(/\/$/, '') || '';
   try {
     const remoteUrl = new URL(directoryUrl);

--- a/src/registry/registry.schema.json
+++ b/src/registry/registry.schema.json
@@ -22,20 +22,14 @@
           "maxLength": 255,
           "title": "Machine Name ID",
           "description": "The widget type identifier across all systems. This ID should be unique per registry.",
-          "examples": [
-            "boilerplate",
-            "foo-bar"
-          ]
+          "examples": ["boilerplate", "foo-bar"]
         },
         "version": {
           "pattern": "^v[0-9]+\\.[0-9]+\\.[0-9]+$",
           "type": "string",
           "title": "Version",
           "description": "The semantic version string for the widget. This is mainly used for change detection.",
-          "examples": [
-            "v0.2.1",
-            "v3.0.1"
-          ]
+          "examples": ["v0.2.1", "v3.0.1"]
         },
         "files": {
           "type": "array",
@@ -55,27 +49,20 @@
           "type": "string",
           "title": "The human readable name for the widget.",
           "description": "This is used in editorial tools to provide a friendlier alternative to \"shortcode\". This property should be unique per registry to avoid confusion, but it is not mandatory.",
-          "examples": [
-            "Boilerplate",
-            "Foo is the Bar"
-          ],
+          "examples": ["Boilerplate", "Foo is the Bar"],
           "maxLength": 255
         },
         "createdAt": {
           "type": "string",
           "format": "date-time",
           "description": "The original date when this was created.",
-          "examples": [
-            "2021-04-28T14:15:03.750Z"
-          ]
+          "examples": ["2021-04-28T14:15:03.750Z"]
         },
         "updatedAt": {
           "type": "string",
           "format": "date-time",
           "description": "The last time this entry was modified.",
-          "examples": [
-            "2021-04-28T14:15:03.750Z"
-          ]
+          "examples": ["2021-04-28T14:15:03.750Z"]
         },
         "settingsSchema": {
           "$ref": "http://json-schema.org/draft-07/schema#",
@@ -89,12 +76,7 @@
           "title": "Status",
           "maxLength": 255,
           "description": "Denotes the status of the widget and its readiness for production.",
-          "enum": [
-            "stable",
-            "beta",
-            "wip",
-            "deprecated"
-          ]
+          "enum": ["stable", "beta", "wip", "deprecated"]
         },
         "help": {
           "type": "string",
@@ -129,12 +111,7 @@
           }
         }
       },
-      "required": [
-        "files",
-        "shortcode",
-        "version",
-        "title"
-      ],
+      "required": ["files", "shortcode", "version", "title"],
       "title": "WidgetRegistryElement"
     }
   },

--- a/src/registry/validateRegistry.ts
+++ b/src/registry/validateRegistry.ts
@@ -8,10 +8,11 @@ import { promisify } from 'util';
 const readFile = promisify(fs.readFile);
 
 // This is necessary so the typescript compiler copies the schema to the dist.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import * as schema from './registry.schema.json';
 
 export default async function validateRegistry(
-  registry: any,
+  registry: unknown,
 ): Promise<WidgetRegistry> {
   const ajv = new Ajv();
   addFormats(ajv);

--- a/src/registry/writeNewRegistry.ts
+++ b/src/registry/writeNewRegistry.ts
@@ -28,10 +28,7 @@ export default async function writeNewRegistry(
     omitMissing,
     existingRegistry,
     widgetDefinitions,
-    await buildTemplatedDirectoryUrl(
-      registryConfig,
-      existingRegistryUrl?.href || '',
-    ),
+    buildTemplatedDirectoryUrl(registryConfig, existingRegistryUrl?.href || ''),
     pathToCompiledWidgets,
     version,
     registryConfig?.externalPeerDependencies || {},

--- a/src/registry/writeNewRegistry.ts
+++ b/src/registry/writeNewRegistry.ts
@@ -5,6 +5,7 @@ import loadExistingRegistry from './loadExistingRegistry';
 import { WidgetDefinition } from 'WidgetDefinition';
 import guessNewVersion from './guessNewVersion';
 import buildTemplatedDirectoryUrl from './buildTemplatedDirectoryUrl';
+import loadWidgetRegistryConfig from '../webpack/widgetDefinition/loadWidgetRegistryConfig';
 
 const writeFile = promisify(fs.writeFile);
 
@@ -22,16 +23,18 @@ export default async function writeNewRegistry(
   if (!version) {
     throw new Error(`Unable to guess the new version for the registry.`);
   }
+  const registryConfig = await loadWidgetRegistryConfig(registryConfigFile);
   const newRegistry = buildNewRegistry(
     omitMissing,
     existingRegistry,
     widgetDefinitions,
     await buildTemplatedDirectoryUrl(
-      registryConfigFile,
+      registryConfig,
       existingRegistryUrl?.href || '',
     ),
     pathToCompiledWidgets,
     version,
+    registryConfig?.externalPeerDependencies || {},
   );
   await writeFile(pathToNewRegistry, JSON.stringify(newRegistry));
   return version;

--- a/src/util/isString.ts
+++ b/src/util/isString.ts
@@ -1,3 +1,3 @@
-export default function isString(input: any): boolean {
+export default function isString(input: unknown): boolean {
   return typeof input === 'string' || input instanceof String;
 }

--- a/src/util/listFilesSync.ts
+++ b/src/util/listFilesSync.ts
@@ -15,7 +15,7 @@ const listFilesSync = (
   folder: string,
   _subpath = '',
   _files: string[] = [],
-) => {
+): string[] => {
   fs.readdirSync(path.join(folder, _subpath)).forEach((file) => {
     if (fs.lstatSync(path.join(folder, _subpath, file)).isDirectory()) {
       listFilesSync(folder, path.join(_subpath, file), _files);

--- a/src/validateOptions.test.ts
+++ b/src/validateOptions.test.ts
@@ -27,13 +27,16 @@ describe('validateOptions', () => {
       existingRegistry: 'https://example.org/tsconfig.json',
       sourceDir: './src/__testData__/validProject',
     };
+    expect.assertions(2);
     try {
       await validateOptions(rawOptions);
-      expect(false).toBe(true);
     } catch (error: unknown) {
-      expect(error.message).toBe(
-        'Unable to find the output dir: "./invalid-path"',
-      );
+      expect(error).toBeInstanceOf(Error);
+      if (error instanceof Error) {
+        expect(error.message).toBe(
+          'Unable to find the output dir: "./invalid-path"',
+        );
+      }
     }
   });
 
@@ -44,13 +47,16 @@ describe('validateOptions', () => {
       existingRegistry: './invalid-path',
       sourceDir: './src/__testData__/validProject',
     };
+    expect.assertions(2);
     try {
       await validateOptions(rawOptions);
-      expect(false).toBe(true);
     } catch (error: unknown) {
-      expect(error.message).toBe(
-        'Invalid URL for the existing registry: "./invalid-path"',
-      );
+      expect(error).toBeInstanceOf(Error);
+      if (error instanceof Error) {
+        expect(error.message).toBe(
+          'Invalid URL for the existing registry: "./invalid-path"',
+        );
+      }
     }
   });
 
@@ -61,13 +67,16 @@ describe('validateOptions', () => {
       existingRegistry: 'https://example.org/tsconfig.json',
       sourceDir: './invalid-directory',
     };
+    expect.assertions(2);
     try {
       await validateOptions(rawOptions);
-      expect(false).toBe(true);
     } catch (error: unknown) {
-      expect(error.message).toBe(
-        'Unable to find the source dir: "./invalid-directory"',
-      );
+      expect(error).toBeInstanceOf(Error);
+      if (error instanceof Error) {
+        expect(error.message).toBe(
+          'Unable to find the source dir: "./invalid-directory"',
+        );
+      }
     }
   });
 
@@ -78,11 +87,16 @@ describe('validateOptions', () => {
       existingRegistry: 'https://example.org/tsconfig.json',
       sourceDir: './tsconfig.json',
     };
+    expect.assertions(2);
     try {
       await validateOptions(rawOptions);
-      expect(false).toBe(true);
     } catch (error: unknown) {
-      expect(error.message).toMatch(/^The provided path is not a directory: /);
+      expect(error).toBeInstanceOf(Error);
+      if (error instanceof Error) {
+        expect(error.message).toMatch(
+          /^The provided path is not a directory: /,
+        );
+      }
     }
   });
 
@@ -93,11 +107,14 @@ describe('validateOptions', () => {
       existingRegistry: 'https://example.org/tsconfig.json',
       sourceDir: './src/__testData__/invalidProject',
     };
+    expect.assertions(2);
     try {
       await validateOptions(rawOptions);
-      expect(false).toBe(true);
     } catch (error: unknown) {
-      expect(error.message).toMatch(/^Unable to find the /);
+      expect(error).toBeInstanceOf(Error);
+      if (error instanceof Error) {
+        expect(error.message).toMatch(/^Unable to find the /);
+      }
     }
   });
 });

--- a/src/validateOptions.test.ts
+++ b/src/validateOptions.test.ts
@@ -30,7 +30,7 @@ describe('validateOptions', () => {
     try {
       await validateOptions(rawOptions);
       expect(false).toBe(true);
-    } catch (error: any) {
+    } catch (error: unknown) {
       expect(error.message).toBe(
         'Unable to find the output dir: "./invalid-path"',
       );
@@ -47,7 +47,7 @@ describe('validateOptions', () => {
     try {
       await validateOptions(rawOptions);
       expect(false).toBe(true);
-    } catch (error: any) {
+    } catch (error: unknown) {
       expect(error.message).toBe(
         'Invalid URL for the existing registry: "./invalid-path"',
       );
@@ -64,7 +64,7 @@ describe('validateOptions', () => {
     try {
       await validateOptions(rawOptions);
       expect(false).toBe(true);
-    } catch (error: any) {
+    } catch (error: unknown) {
       expect(error.message).toBe(
         'Unable to find the source dir: "./invalid-directory"',
       );
@@ -81,7 +81,7 @@ describe('validateOptions', () => {
     try {
       await validateOptions(rawOptions);
       expect(false).toBe(true);
-    } catch (error: any) {
+    } catch (error: unknown) {
       expect(error.message).toMatch(/^The provided path is not a directory: /);
     }
   });
@@ -96,7 +96,7 @@ describe('validateOptions', () => {
     try {
       await validateOptions(rawOptions);
       expect(false).toBe(true);
-    } catch (error: any) {
+    } catch (error: unknown) {
       expect(error.message).toMatch(/^Unable to find the /);
     }
   });

--- a/src/validateOptions.ts
+++ b/src/validateOptions.ts
@@ -9,7 +9,7 @@ import { CLIOptions } from 'CLIOptions';
 const stat = promisify(fs.stat);
 
 export default async function validateOptions(
-  rawOptions: Record<string, any>,
+  rawOptions: Record<string, unknown>,
 ): Promise<CLIOptions> {
   const {
     debug,
@@ -20,21 +20,25 @@ export default async function validateOptions(
     newVersion,
   } = rawOptions;
   let isDir = false;
+  // Some string casting to deal easily with types.
+  const outDir = `${outputDir}`;
+  const srcDir = `${sourceDir}`;
+  const newVer = `${newVersion}`;
   try {
-    isDir = (await stat(outputDir)).isDirectory();
-  } catch (e: any) {
-    throw new Error(`Unable to find the output dir: "${outputDir}"`);
+    isDir = (await stat(outDir)).isDirectory();
+  } catch (error: unknown) {
+    throw new Error(`Unable to find the output dir: "${outDir}"`);
   }
   if (!isDir) {
     throw new Error(
-      `The provided path is not a directory: "${path.resolve(outputDir)}"`,
+      `The provided path is not a directory: "${path.resolve(outDir)}"`,
     );
   }
   let theUrl;
   if (existingRegistry) {
     try {
-      theUrl = new URL(existingRegistry);
-    } catch (e: any) {
+      theUrl = new URL(`${existingRegistry}`);
+    } catch (error: unknown) {
       throw new Error(
         `Invalid URL for the existing registry: "${existingRegistry}"`,
       );
@@ -47,20 +51,20 @@ export default async function validateOptions(
   }
 
   try {
-    isDir = (await stat(sourceDir)).isDirectory();
-  } catch (e: any) {
-    throw new Error(`Unable to find the source dir: "${sourceDir}"`);
+    isDir = (await stat(srcDir)).isDirectory();
+  } catch (error: unknown) {
+    throw new Error(`Unable to find the source dir: "${srcDir}"`);
   }
   if (!isDir) {
     throw new Error(
-      `The provided path is not a directory: "${path.resolve(sourceDir)}"`,
+      `The provided path is not a directory: "${path.resolve(srcDir)}"`,
     );
   }
   let isFile = false;
-  const configFile = path.join(sourceDir, '.widgetRegistry', 'main.js');
+  const configFile = path.join(srcDir, '.widgetRegistry', 'main.js');
   try {
     isFile = (await stat(configFile)).isFile();
-  } catch (e: any) {}
+  } catch (error: unknown) {}
   if (!isFile) {
     throw new Error(
       `Unable to find the main config file for the registry: "${configFile}"`,
@@ -68,7 +72,7 @@ export default async function validateOptions(
   }
   let version;
   if (newVersion) {
-    version = `v${coerceSemver(newVersion)}`;
+    version = `v${coerceSemver(newVer)}`;
     if (!validateSemver(version)) {
       throw new Error(
         `The new version is not a valid semver specifier (vX.Y.Z): "${version}"`,
@@ -78,9 +82,9 @@ export default async function validateOptions(
   return {
     debug: !!debug,
     omitMissing: !!omitMissing,
-    outputDir: path.resolve(outputDir),
+    outputDir: path.resolve(outDir),
     existingRegistry: theUrl,
-    sourceDir: path.resolve(sourceDir),
+    sourceDir: path.resolve(srcDir),
     configFile: path.resolve(configFile),
     newVersion: version,
   };

--- a/src/webpack/buildWebpackConfiguration.ts
+++ b/src/webpack/buildWebpackConfiguration.ts
@@ -2,13 +2,14 @@ import path from 'path';
 import { Configuration } from 'webpack';
 import { WidgetDefinition } from 'WidgetDefinition';
 import { RegistryConfig } from 'RegistryConfig';
+import { SideEffects } from 'common';
 
 export default async function buildWebpackConfiguration(
   definitions: WidgetDefinition[],
   configuration: Configuration,
   registryConfig: string,
   outputDir: string,
-  logger?: (input: string) => void,
+  logger?: SideEffects,
 ): Promise<Configuration> {
   let configData: RegistryConfig;
   try {
@@ -27,15 +28,15 @@ export default async function buildWebpackConfiguration(
         {},
       );
     }
-  } catch (error: any) {
+  } catch (error: unknown) {
     logger && logger(error);
   }
-  const entry: Record<string, any> = {};
+  configuration.entry = {};
   for (const definition of definitions) {
     const libName = `render-${definition.shortcode}`.replace(/-./g, (match) =>
       match[1].toUpperCase(),
     );
-    entry[definition.shortcode] = {
+    configuration.entry[definition.shortcode] = {
       import: definition.entry,
       library: {
         name: libName,
@@ -44,7 +45,6 @@ export default async function buildWebpackConfiguration(
       },
     };
   }
-  configuration.entry = entry;
   if (typeof configuration.output === 'undefined') {
     configuration.output = {};
   }

--- a/src/webpack/buildWebpackConfiguration.ts
+++ b/src/webpack/buildWebpackConfiguration.ts
@@ -23,10 +23,12 @@ export default async function buildWebpackConfiguration(
       configuration.externals = Object.keys(externalPeerDependencies).reduce(
         (ext, key) => ({
           ...ext,
-          [key]: externalPeerDependencies[key].varName,
+          [key]: externalPeerDependencies[key].external,
         }),
         {},
       );
+      configuration.externalsPresets = { webAsync: true };
+      configuration.externalsType = 'window';
     }
   } catch (error: unknown) {
     logger && logger(error);

--- a/src/webpack/buildWebpackConfiguration.ts
+++ b/src/webpack/buildWebpackConfiguration.ts
@@ -17,6 +17,16 @@ export default async function buildWebpackConfiguration(
     if (configData.webpackFinal) {
       configuration = await configData.webpackFinal(configuration);
     }
+    const { externalPeerDependencies = {} } = configData;
+    if (Object.keys(externalPeerDependencies).length) {
+      configuration.externals = Object.keys(externalPeerDependencies).reduce(
+        (ext, key) => ({
+          ...ext,
+          [key]: externalPeerDependencies[key].varName,
+        }),
+        {},
+      );
+    }
   } catch (error: any) {
     logger && logger(error);
   }

--- a/src/webpack/widgetDefinition/discoverWidgetDefinitionFiles.ts
+++ b/src/webpack/widgetDefinition/discoverWidgetDefinitionFiles.ts
@@ -1,7 +1,6 @@
 import glob from 'glob';
 import { dirname, join, resolve as resolvePath } from 'path';
 
-import { RegistryConfig } from 'RegistryConfig';
 import loadWidgetRegistryConfig from './loadWidgetRegistryConfig';
 
 /**

--- a/src/webpack/widgetDefinition/loadWidgetRegistryConfig.ts
+++ b/src/webpack/widgetDefinition/loadWidgetRegistryConfig.ts
@@ -11,7 +11,7 @@ export default async function loadWidgetRegistryConfig(
   const defaultData: RegistryConfig = { directoryUrl: '', register: [] };
   try {
     configData = { ...defaultData, ...(await import(filename)) };
-  } catch (error: any) {
+  } catch (error: unknown) {
     return defaultData;
   }
   return configData;

--- a/src/webpack/widgetDefinition/validateWidgetDefinitionFile.ts
+++ b/src/webpack/widgetDefinition/validateWidgetDefinitionFile.ts
@@ -9,7 +9,17 @@
  */
 import isString from '../../util/isString';
 
-export default function validateWidgetDefinitionFile(importData: any): void {
+type WidgetDefinitionImportData = Partial<{
+  entry: unknown;
+  shortcode: unknown;
+  title: unknown;
+  status: unknown;
+  settingsSchema: unknown;
+}>;
+
+export default function validateWidgetDefinitionFile(
+  importData: WidgetDefinitionImportData,
+): void {
   const { entry, shortcode, title, status, settingsSchema } = importData;
   if (!entry || !shortcode) {
     throw new Error(
@@ -29,7 +39,7 @@ export default function validateWidgetDefinitionFile(importData: any): void {
     throw new Error('Unexpected type: "status" should be a string.');
   }
   const validStatuses = ['stable', 'beta', 'wip', 'deprecated'];
-  if (validStatuses.indexOf(status) === -1) {
+  if (validStatuses.indexOf(`${status}`) === -1) {
     throw new Error(
       `Unexpected status value: allowed values are ${validStatuses.join(', ')}`,
     );

--- a/types/RegistryConfig.d.ts
+++ b/types/RegistryConfig.d.ts
@@ -10,7 +10,7 @@ export type RegistryConfig = {
     string,
     {
       src: string;
-      varName: string;
+      external: keyof Configuration['externals'];
     }
   >;
 };

--- a/types/RegistryConfig.d.ts
+++ b/types/RegistryConfig.d.ts
@@ -6,4 +6,11 @@ export type RegistryConfig = {
   register: string[];
   directoryUrl: string;
   webpackFinal?: HOFP<WebpackOptionsNormalized | Configuration>;
+  externalPeerDependencies?: Record<
+    string,
+    {
+      src: string;
+      varName: string;
+    }
+  >;
 };

--- a/types/WidgetDefinition.d.ts
+++ b/types/WidgetDefinition.d.ts
@@ -1,5 +1,6 @@
 import { EntryObject } from 'webpack';
 import { Schema } from 'ajv';
+import { RegistryConfig } from 'RegistryConfig';
 
 export type WidgetMetadataBasic = {
   shortcode: string;
@@ -10,6 +11,7 @@ export type WidgetMetadataBasic = {
   };
   description?: string;
   additionalCustomProperties?: Record<string, scalar>;
+  externalPeerDependencies?: RegistryConfig['externalPeerDependencies'];
 };
 
 export type WidgetDefinition = WidgetMetadataBasic & { entry: EntryObject };

--- a/types/WidgetDefinition.d.ts
+++ b/types/WidgetDefinition.d.ts
@@ -1,4 +1,3 @@
-import { EntryObject } from 'webpack';
 import { Schema } from 'ajv';
 import { RegistryConfig } from 'RegistryConfig';
 
@@ -14,4 +13,4 @@ export type WidgetMetadataBasic = {
   externalPeerDependencies?: RegistryConfig['externalPeerDependencies'];
 };
 
-export type WidgetDefinition = WidgetMetadataBasic & { entry: EntryObject };
+export type WidgetDefinition = WidgetMetadataBasic & { entry: string };

--- a/types/WidgetDefinition.d.ts
+++ b/types/WidgetDefinition.d.ts
@@ -1,5 +1,4 @@
 import { Schema } from 'ajv';
-import { RegistryConfig } from 'RegistryConfig';
 
 export type WidgetMetadataBasic = {
   shortcode: string;
@@ -10,7 +9,9 @@ export type WidgetMetadataBasic = {
   };
   description?: string;
   additionalCustomProperties?: Record<string, scalar>;
-  externalPeerDependencies?: RegistryConfig['externalPeerDependencies'];
 };
 
-export type WidgetDefinition = WidgetMetadataBasic & { entry: string };
+export type WidgetDefinition = WidgetMetadataBasic & {
+  entry: string;
+  useExternalPeerDependencies: string[];
+};

--- a/types/WidgetRegistry.d.ts
+++ b/types/WidgetRegistry.d.ts
@@ -6,6 +6,7 @@ type WidgetRegistryItem = WidgetMetadataBasic & {
   files: string[];
   createdAt: string;
   updatedAt: string;
+  externalPeerDependencies?: Record<string, { src: string }>;
 };
 
 export type WidgetRegistry = WidgetRegistryItem[];

--- a/types/common.ts
+++ b/types/common.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type SideEffects = (input?: any) => void;

--- a/website/docs/registry/config/declare-registry.md
+++ b/website/docs/registry/config/declare-registry.md
@@ -1,10 +1,12 @@
 ---
 sidebar_position: 1
 ---
+
 # Declare the Registry
 
-In order to get started you need to make your repository compatible with the widget registry. For this you will need to
-create a special folder (once for the repository) called `.widgetRegistry`.  This folder should contain a `main.js`
+In order to get started you need to make your repository compatible with the
+widget registry. For this you will need to create a special folder (once for the
+repository) called `.widgetRegistry`. This folder should contain a `main.js`
 file that holds configuration and metadata for the whole registry.
 
 An example `.widgetRegistry/main.js` could look like:
@@ -21,7 +23,7 @@ module.exports = {
     // the default webpack config.
     let presets = config.module.rules[2].use.options.presets;
     presets.push('@babel/preset-react');
-    
+
     // This repository is not using TypeScript. Opt out.
     presets = presets.filter((preset) => preset !== '@babel/preset-typescript');
     config.module.rules[2].use.options.presets = presets;
@@ -29,11 +31,19 @@ module.exports = {
       (rule) => rule.loader !== 'ts-loader'
     );
     return config;
+  },
+  allExternalPeerDependencies: {
+    lodash: {
+      src: 'https://cdn.jsdelivr.net/npm/lodash@4/lodash.min.js',
+      external: '_',
+    },
   }
 }
 ```
 
 Options:
-  - [`register`](/docs/registry/config/options/register)
-  - [`directoryUrl`](/docs/registry/config/options/directoryUrl)
-  - [`webpackFinal`](/docs/registry/config/options/webpackFinal)
+
+- [`register`](/docs/registry/config/options/register)
+- [`directoryUrl`](/docs/registry/config/options/directoryUrl)
+- [`webpackFinal`](/docs/registry/config/options/webpackFinal)
+- [`allExternalPeerDependencies`](/docs/registry/config/options/allExternalPeerDependencies)

--- a/website/docs/registry/config/options/externalPeerDependencies.md
+++ b/website/docs/registry/config/options/externalPeerDependencies.md
@@ -1,0 +1,42 @@
+---
+title: allExternalPeerDependencies
+sidebar_position: 4 
+---
+
+# `allExternalPeerDependencies`: `Object`
+
+The actual TS type for this property is:
+
+```typescript
+Record<string, { src: string; external: External; }>
+```
+
+[Externals](https://webpack.js.org/configuration/externals) are a technique in Webpack to defer bundling certain dependencies with the rest of the widget. This is useful for dependencies that are very common. This way you can have five widgets embedded in a single page, and download, parse and execute ReactDOM (for instance) only once.
+
+To be successful this technique requires the CMS and the widget to have matching configuration. To this end, the compiler, internally, will do two things:
+
+  - Tell Webpack to not include the listed dependencies in the JS bundle for the widget.
+  - Leave some additional configuration in the `registry.json`. Later on, the CMS will ingest this, and will know to add the dependency to the page whenever this widget is embedded.
+
+The registry configuration will declare all the dependencies that may be externalized. Then each [widget definition file](../../widget-definition) will choose which ones are applicable to each widget.
+
+For each dependency you will need to provide:
+
+  - The name of the module for the key of the object. This is the name from the import (`lodash`): `import _ from 'lodash'`.
+  - The configuration for the external in Webpack. This is _typically_ the name of the variable (`_`): `import _ from 'lodash'`. Refer to the [externals documentation for Webpack](https://webpack.js.org/configuration/externals) for more nuanced information and examples.
+  - The CDN url from where the CMS will load this dependency.
+
+:::note
+`@js-widgets/webpack-cli` will set `externalsType` to `'window'`, and `externalsPresets` to `{ webAsync: true }` internally. This may have an effect depending on what configuration you set on `external`.
+:::
+
+## Examples
+
+```
+{
+  lodash: {
+    src: 'https://cdn.jsdelivr.net/npm/lodash@4/lodash.min.js',
+    external: '_',
+  },
+}
+```

--- a/website/docs/registry/widget-definition.mdx
+++ b/website/docs/registry/widget-definition.mdx
@@ -2,7 +2,8 @@
 sidebar_position: 3
 title: 1.2. Widget Definition
 ---
-import Link from '@docusaurus/Link';
+
+import Link from "@docusaurus/Link";
 
 Once you have [configured the registry](./config/declare-registry) it's time to create a widget definitions for one of
 your components.
@@ -24,8 +25,6 @@ src/components/notification/toast-notification.widget.js
 ```
 
 ```js title="src/components/notification/toast-notification.widget.js"
-const path = require('path');
-
 module.exports = {
   shortcode: 'toast-notification',
   title: 'Toast Notification',
@@ -69,6 +68,7 @@ module.exports = {
   title: 'Toast Notification',
   description: 'A notification element with a bit more context than the inline notification.',
   status: 'wip',
+  usesExternalPeerDependencies: ['react', 'react-dom'],
   // highlight-start
   settingsSchema: {
     type: 'object',
@@ -119,4 +119,5 @@ Properties:
   - [`description`](https://js-widgets.github.io/js-widgets/registry-schema/#items_description)
   - [`status`](https://js-widgets.github.io/js-widgets/registry-schema/#items_status)
   - [`settingsSchema`](https://js-widgets.github.io/js-widgets/registry-schema/#items_settingsSchema)
-  - `entry`: the path to [the render file](./render-file) for the component.
+  - `usesExternalPeerDependencies` (`string[]`): The list of keys of [external peer dependencies](./config/options/allExternalPeerDependencies) this widget uses.
+  - `entry` (`string`): the path to [the render file](./render-file) for the component. Default: `./index.js`.


### PR DESCRIPTION
With this change you can now add an `externalPeerDependencies` key to your `.widgetRegistry/main.js` file. This key will be used for two different purposes: it will affect the webpack configuration, and it will alter the contents of `registry.json`.

Let's imagine this configuration:

```js
// .widgetRegistry/main.js
module.exports = {
  // ...
  externalPeerDependencies: {
    react: {
      src: 'https://unpkg.com/react@^17/umd/react.production.min.js',
      varName: 'React',
    },
    'react-dom': {
      src: 'https://unpkg.com/react-dom@^17/umd/react-dom.production.min.js',
      varName: 'ReactDOM',
    },
    'react-intl': {
      src: 'https://unpkg.com/react-intl-bundle@^1/dist/react-intl.production.min.js',
      varName: 'ReactIntl',
    },
  },
};
```

Then our widget configuration file contains:

```js
// MyWidget.widget.js
module.exports = {
  // ...
  usesExternalPeerDependencies: ['react', 'react-dom'],
};
```

With this configuration we aim to:

1. Tell the dynamic webpack configuration to add an [`externals`](https://webpack.js.org/configuration/externals) entry based on each key, and the `varName`. In our case we would add `externals: { react: 'React', react-dom: ReactDOM }` to the webpack configuration that compiles the widgets. That means that each time webpack encounters `import React from 'react'` ,while compiling your widgets, it will not put react in the bundle.
2. Alter the generated `registry.json` file. We aim to add the `externalPeerDependencies` key to each widget in the `registry.json`. This will instruct the CMS to add `https://unpkg.com/react@^17/umd/react.production.min` whenever those widgets are rendered. We want the CMS to skip unnecessary peer dependencies for a given widget. If `MyWidget` uses `react` and `react-dom` but it does not use `react-intl`, then its configuration should only contain the necessary dependencies. This way the CMS will not add `react-intl` to the page when rendering `MyWidget`.