### PR TITLE
feat: webpack improvements

### DIFF
--- a/src/registry/loadExistingRegistry.ts
+++ b/src/registry/loadExistingRegistry.ts
@@ -9,6 +9,7 @@ export default async function loadExistingRegistry(
   if (!fileUrl) {
     return [];
   }
-  const existingRegistry = JSON.parse(await downloadFileContents(fileUrl));
+  const fileContents = await downloadFileContents(fileUrl);
+  const existingRegistry = JSON.parse(fileContents);
   return validateRegistry(existingRegistry);
 }

--- a/src/registry/registry.schema.json
+++ b/src/registry/registry.schema.json
@@ -82,7 +82,7 @@
           "type": "object",
           "nullable": true,
           "title": "Editorial Display Options",
-          "description": "Used by widget developers to create reusable widget types. Allows JS widget developers to specify input data that the widget needs.\n\nSome examples for this could include:\n\n - _Content for a CTA button_.\n - _A radio button to select dark mode_, \n - _a checklist to only display certain products on the widget_.\n - _A text field to specify an API endpoint_.\n - etc.\n\nThis uses the JSON Schema format for each one of the fields, then each CMS integration will transform that into a form that editors will use for data input. Data provided by editors will then be serialized and rendered as `\"data-[name-of-field]\"` attributes in the wrapper `div` for the widget.",
+          "description": "Used by widget developers to create reusable widget types. Allows JS widget developers to specify input data that the widget needs.\n\nSome examples for this could include:\n\n - _Content for a CTA button_.\n - _A radio button to select dark mode_, \n - _a checklist to only display certain products on the widget_.\n - _A text field to specify an API endpoint_.\n - etc.\n\nThis uses the JSON Schema format for each one of the fields, then each CMS integration will transform that into a form that editors will use for data input. Data provided by editors will then be serialized and rendered as `\"data-[name-of-field]\"` attributes in the wrapper `div` for the widget."
         },
         "status": {
           "type": "string",

--- a/src/registry/validateRegistry.ts
+++ b/src/registry/validateRegistry.ts
@@ -2,7 +2,10 @@ import Ajv, { JSONSchemaType } from 'ajv';
 import addFormats from 'ajv-formats';
 import path from 'path';
 import { WidgetRegistry } from 'WidgetRegistry';
-import fs from 'fs/promises';
+import fs from 'fs';
+import { promisify } from 'util';
+
+const readFile = promisify(fs.readFile);
 
 // This is necessary so the typescript compiler copies the schema to the dist.
 import * as schema from './registry.schema.json';
@@ -14,9 +17,14 @@ export default async function validateRegistry(
   addFormats(ajv);
   const schemaFilename = path.join(__dirname, './registry.schema.json');
   // This is the way to refine the type for input data into TypeScript.
-  const schema: JSONSchemaType<WidgetRegistry> = JSON.parse(
-    (await fs.readFile(schemaFilename)).toString(),
-  );
+  const schemaContents = await readFile(schemaFilename);
+  let schema: JSONSchemaType<WidgetRegistry>;
+  try {
+    schema = JSON.parse(schemaContents.toString());
+  } catch (e) {
+    console.log(schemaContents.toString());
+    throw new Error('Invalid registry. Unable to parse registry schema.');
+  }
   const validate = ajv.compile(schema);
   const valid = validate(registry);
   if (!valid) {

--- a/src/registry/writeNewRegistry.ts
+++ b/src/registry/writeNewRegistry.ts
@@ -1,9 +1,12 @@
-import fs from 'fs/promises';
+import fs from 'fs';
+import { promisify } from 'util';
 import buildNewRegistry from './buildNewRegistry';
 import loadExistingRegistry from './loadExistingRegistry';
 import { WidgetDefinition } from 'WidgetDefinition';
 import guessNewVersion from './guessNewVersion';
 import buildTemplatedDirectoryUrl from './buildTemplatedDirectoryUrl';
+
+const writeFile = promisify(fs.writeFile);
 
 export default async function writeNewRegistry(
   omitMissing: boolean,
@@ -30,6 +33,6 @@ export default async function writeNewRegistry(
     pathToCompiledWidgets,
     version,
   );
-  await fs.writeFile(pathToNewRegistry, JSON.stringify(newRegistry));
+  await writeFile(pathToNewRegistry, JSON.stringify(newRegistry));
   return version;
 }

--- a/src/validateOptions.ts
+++ b/src/validateOptions.ts
@@ -1,9 +1,12 @@
-import fs from 'fs/promises';
+import fs from 'fs';
+import { promisify } from 'util';
 import path from 'path';
 import { URL } from 'url';
 import coerceSemver from 'semver/functions/coerce';
 import validateSemver from 'semver/functions/valid';
 import { CLIOptions } from 'CLIOptions';
+
+const stat = promisify(fs.stat);
 
 export default async function validateOptions(
   rawOptions: Record<string, any>,
@@ -18,7 +21,7 @@ export default async function validateOptions(
   } = rawOptions;
   let isDir = false;
   try {
-    isDir = (await fs.stat(outputDir)).isDirectory();
+    isDir = (await stat(outputDir)).isDirectory();
   } catch (e: any) {
     throw new Error(`Unable to find the output dir: "${outputDir}"`);
   }
@@ -44,7 +47,7 @@ export default async function validateOptions(
   }
 
   try {
-    isDir = (await fs.stat(sourceDir)).isDirectory();
+    isDir = (await stat(sourceDir)).isDirectory();
   } catch (e: any) {
     throw new Error(`Unable to find the source dir: "${sourceDir}"`);
   }
@@ -56,7 +59,7 @@ export default async function validateOptions(
   let isFile = false;
   const configFile = path.join(sourceDir, '.widgetRegistry', 'main.js');
   try {
-    isFile = (await fs.stat(configFile)).isFile();
+    isFile = (await stat(configFile)).isFile();
   } catch (e: any) {}
   if (!isFile) {
     throw new Error(

--- a/src/webpack/buildWebpackConfiguration.ts
+++ b/src/webpack/buildWebpackConfiguration.ts
@@ -6,13 +6,14 @@ import { RegistryConfig } from 'RegistryConfig';
 export default async function buildWebpackConfiguration(
   definitions: WidgetDefinition[],
   configuration: Configuration,
-  RegistryConfig: string,
+  registryConfig: string,
   outputDir: string,
   logger?: (input: string) => void,
 ): Promise<Configuration> {
   let configData: RegistryConfig;
   try {
-    configData = await import(RegistryConfig);
+    const importData = await import(registryConfig);
+    configData = importData?.default || importData;
     if (configData.webpackFinal) {
       configuration = await configData.webpackFinal(configuration);
     }

--- a/src/webpack/buildWebpackConfiguration.ts
+++ b/src/webpack/buildWebpackConfiguration.ts
@@ -40,7 +40,7 @@ export default async function buildWebpackConfiguration(
   configuration.output.path = path.join(outputDir, 'widgets');
   configuration.output.filename =
     configuration.mode === 'production'
-      ? '[name]/js/main-[hash:6].js'
+      ? '[name]/js/main-[fullhash:6].js'
       : '[name]/js/main.js';
   configuration.output.assetModuleFilename = '[name]/images/[hash][ext][query]';
   if (logger) {

--- a/src/webpack/buildWebpackConfiguration.ts
+++ b/src/webpack/buildWebpackConfiguration.ts
@@ -21,7 +21,16 @@ export default async function buildWebpackConfiguration(
   }
   const entry: Record<string, any> = {};
   for (const definition of definitions) {
-    entry[definition.shortcode] = definition.entry;
+    const libName = `render-${definition.shortcode}`.replace(/-./g, (match) =>
+      match[1].toUpperCase(),
+    );
+    entry[definition.shortcode] = {
+      import: definition.entry,
+      library: {
+        name: libName,
+        type: 'window',
+      },
+    };
   }
   configuration.entry = entry;
   if (typeof configuration.output === 'undefined') {

--- a/src/webpack/widgetDefinition/loadWidgetDefinitionFile.ts
+++ b/src/webpack/widgetDefinition/loadWidgetDefinitionFile.ts
@@ -1,5 +1,6 @@
 import { WidgetDefinition } from 'WidgetDefinition';
 import validateWidgetDefinitionFile from './validateWidgetDefinitionFile';
+import { dirname, join } from 'path';
 
 /**
  * Loads the widget definition file.
@@ -10,6 +11,10 @@ export default async function loadWidgetDefinitionFile(
   filename: string,
 ): Promise<WidgetDefinition> {
   const importData = await import(filename);
+  // If there is no entry point defined, use `index.tsx` in that folder.
+  if (typeof importData.entry === 'undefined') {
+    importData.entry = join(dirname(filename), 'index.js');
+  }
   validateWidgetDefinitionFile(importData);
   return importData;
 }

--- a/website/docs/i18n.md
+++ b/website/docs/i18n.md
@@ -13,7 +13,7 @@ translation in the [render file](./registry/render-file).
 
 Take this React example of the render file:
 
-```js title="src/components/notification/render-toast-notification.js"
+```js title="src/components/notification/index.js"
 import React from 'react';
 import ReactDOM from 'react-dom';
 import './index.scss';

--- a/website/docs/registry/render-file.mdx
+++ b/website/docs/registry/render-file.mdx
@@ -15,10 +15,6 @@ JavaScript application will render inside that `<div>`.
 Rendering a component is heavily dependent on the JS framework you are using. This step will look different for React,
 Vue, Angular, Web Components, ...
 
-:::caution Check the render function name!
-All the render files contain `window.renderXXXX`, where `XXXX` needs to be the same as the [`shortcode` property](./widget-definition) in [camel case](https://en.wikipedia.org/wiki/Camel_case).
-:::
-
 <Tabs
   defaultValue="react"
   values={[
@@ -31,7 +27,7 @@ All the render files contain `window.renderXXXX`, where `XXXX` needs to be the s
 
 <TabItem value="wc">
 
-```js title="src/components/notification/render-toast-notification.js"
+```js title="src/components/notification/index.js"
 require('./toast-notification');
 
 /**
@@ -47,8 +43,11 @@ require('./toast-notification');
  *   Protocol and hostname where a JSONAPI endpoint is available.
  * @param {Function} cb
  *   A callback that executes after the widget has been rendered.
+ *
+ * @return {Promise<void>}
+ *   The async render function.
  */
-const render = (instanceId, langCode, origin, cb) => {
+module.exports = async function(instanceId, langCode, origin, cb) => {
   const element = document.getElementById(instanceId);
   if (!element) {
     return;
@@ -65,14 +64,12 @@ const render = (instanceId, langCode, origin, cb) => {
   // Execute the callback so the parent process knows we are done rendering.
   cb(element);
 };
-
-window.renderToastNotification = render;
 ```
 
 </TabItem>
 <TabItem value="react">
 
-```js title="src/components/notification/render-toast-notification.js"
+```js title="src/components/notification/index.js"
 import React from 'react';
 import ReactDOM from 'react-dom';
 import './index.scss';
@@ -94,8 +91,11 @@ import i18n from './core/bin/i18n.js';
  *   Protocol and hostname where a JSONAPI endpoint is available.
  * @param {Function} cb
  *   A callback that executes after the widget has been rendered.
+ *
+ * @return {Promise<void>}
+ *   The async render function.
  */
-function render(instanceId, langCode, origin, cb) {
+module.exports = async function(instanceId, langCode, origin, cb) => {
   const element = document.getElementById(instanceId);
   const translation = new i18n(langCode || serviceWorker.getUrlLocale());
 
@@ -117,8 +117,6 @@ function render(instanceId, langCode, origin, cb) {
   );
   serviceWorker.unregister();
 }
-
-window.renderToastNotification = render;
 ```
 
 </TabItem>

--- a/website/docs/registry/widget-definition.mdx
+++ b/website/docs/registry/widget-definition.mdx
@@ -27,7 +27,6 @@ src/components/notification/toast-notification.widget.js
 const path = require('path');
 
 module.exports = {
-  entry: path.join(__dirname, 'render-toast-notification.js'),
   shortcode: 'toast-notification',
   title: 'Toast Notification',
   description: 'A notification element with a bit more context than the inline notification.',
@@ -66,7 +65,8 @@ Let's add three text boxes and one radio button to collect the _Toast Notificati
 const path = require('path');
 
 module.exports = {
-  entry: path.join(__dirname, 'render-toast-notification.js'),
+  // entry defaults to 'index.js' but you can change it to any other location.
+  // entry: path.join(__dirname, 'render-toast-notification.js'),
   shortcode: 'toast-notification',
   title: 'Toast Notification',
   description: 'A notification element with a bit more context than the inline notification.',

--- a/website/docs/registry/widget-definition.mdx
+++ b/website/docs/registry/widget-definition.mdx
@@ -62,8 +62,6 @@ The syntax to describe the configurable options is the [JSON Schema standard](ht
 Let's add three text boxes and one radio button to collect the _Toast Notification_ options.
 
 ```js title="src/components/notification/toast-notification.widget.js"
-const path = require('path');
-
 module.exports = {
   // entry defaults to 'index.js' but you can change it to any other location.
   // entry: path.join(__dirname, 'render-toast-notification.js'),


### PR DESCRIPTION
This will allow omitting the `entry` in the widget definition file. This is because we'll default to `index.js`.

BREAKING CHANGE: It also leverages webpack to create the `window.renderMyWidget = ...`. One only needs to export a function from now on. This is a breaking change, since render files need an export now.