### PR TITLE
feat: allow altering all configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "build:watch": "tsc --watch",
     "test": "jest",
     "test:ci": "yarn test --watchAll=false --coverage",
     "lint": "eslint .",

--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base"
-  ],
+  "extends": ["config:base"],
   "rangeStrategy": "bump",
   "lockFileMaintenance": {
     "enabled": true,

--- a/src/command.ts
+++ b/src/command.ts
@@ -29,7 +29,7 @@ function initProgram(program: Command, argv: string[]): void {
     )
     .option(
       '--widget-definitions <widget-definitions>',
-      'when used, the glob(s) provided here will supersede the "register" key in the config file. Use commas to separate multiple values. Relative glob patterns are interpreted from the .widgetRegistry/ location.',
+      'when used, the glob(s) provided here will supersede the "register" key in the config file. Use commas to separate multiple values.',
     )
     .option(
       '--omit-missing',

--- a/src/defaultConfig/webpack.config.js
+++ b/src/defaultConfig/webpack.config.js
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
-const CopyPlugin = require('copy-webpack-plugin');
 const { EnvironmentPlugin } = require('webpack');
 /* eslint-enable @typescript-eslint/no-var-requires */
 

--- a/src/webpack/__snapshots__/buildWebpackConfiguration.test.ts.snap
+++ b/src/webpack/__snapshots__/buildWebpackConfiguration.test.ts.snap
@@ -112,6 +112,7 @@ Object {
         Object {
           "context": ".",
           "from": "thumbnail.png",
+          "noErrorOnMissing": true,
           "to": "src/__testData__/widgetDefinitions/widgets/fake/[name].[contenthash:8][ext]",
         },
       ],

--- a/src/webpack/buildWebpackConfiguration.ts
+++ b/src/webpack/buildWebpackConfiguration.ts
@@ -15,7 +15,8 @@ export default async function buildWebpackConfiguration(
 ): Promise<Configuration> {
   let configData: RegistryConfig;
   // Default to do no changes if it is not defined.
-  let webpackFinal = (c: Configuration): Promise<Configuration> => Promise.resolve(c);
+  let webpackFinal = (c: Configuration): Promise<Configuration> =>
+    Promise.resolve(c);
   try {
     const importData = await import(registryConfig);
     configData = importData?.default || importData;

--- a/src/webpack/buildWebpackConfiguration.ts
+++ b/src/webpack/buildWebpackConfiguration.ts
@@ -14,11 +14,13 @@ export default async function buildWebpackConfiguration(
   logger?: SideEffects,
 ): Promise<Configuration> {
   let configData: RegistryConfig;
+  // Default to do no changes if it is not defined.
+  let webpackFinal = (c: Configuration): Promise<Configuration> => Promise.resolve(c);
   try {
     const importData = await import(registryConfig);
     configData = importData?.default || importData;
     if (configData.webpackFinal) {
-      configuration = await configData.webpackFinal(configuration);
+      webpackFinal = configData.webpackFinal;
     }
     const { externalPeerDependencies = {} } = configData;
     if (Object.keys(externalPeerDependencies).length) {
@@ -66,11 +68,14 @@ export default async function buildWebpackConfiguration(
       definition.shortcode,
       '[name].[contenthash:8][ext]',
     ),
+    noErrorOnMissing: true,
     context: path.dirname(definition.entry),
   }));
   if (copyOptions.length) {
     configuration.plugins?.push(new CopyPlugin({ patterns: copyOptions }));
   }
+  // Execute the function in .widgetRegistry/main.js
+  configuration = await webpackFinal(configuration);
   if (logger) {
     logger('\n---------------------------------------------------');
     logger('              Webpack Config                       ');

--- a/src/webpack/widgetDefinition/discoverWidgetDefinitionFiles.ts
+++ b/src/webpack/widgetDefinition/discoverWidgetDefinitionFiles.ts
@@ -20,11 +20,15 @@ export default async function discoverWidgetDefinitionFiles(
   widgetDefinitionGlobs: string[],
 ): Promise<string[]> {
   const configData = await loadWidgetRegistryConfig(configFile);
-  const workingDir = dirname(configFile);
+  let workingDir = dirname(configFile);
+  let register = configData.register;
+  // If there are widget definitions coming from the CLI they are relative to
+  // the current working directory.
+  if (widgetDefinitionGlobs.length) {
+    workingDir = process.cwd();
+    register = widgetDefinitionGlobs;
+  }
   // Discover the widget definitions based on the glob pattern.
-  const register = widgetDefinitionGlobs.length
-    ? widgetDefinitionGlobs
-    : configData.register;
   const unflattenned = await Promise.all(
     register.map((pattern): Promise<string[]> => {
       return new Promise((resolve, reject) =>


### PR DESCRIPTION
Fixes #112 #113 #114.

BREAKING CHANGE: webpackFinal from user land will receive a configuration object with additional autocomputed properties.
BREAKING CHANGE: --widget-definitions CLI option now interprets paths from CWD and not as if they came from the config file.